### PR TITLE
Fix: Improve TSX syntax highlighting for Alpine.js directives

### DIFF
--- a/syntaxes/injection.json
+++ b/syntaxes/injection.json
@@ -4,7 +4,7 @@
         "L:text.html.derivative",
         "L:text.html.php",
         "L:text.html.twig",
-        "L:source.tsx"
+        "L:source.tsx#meta.tag.tsx"
     ],
     "patterns": [
         {

--- a/syntaxes/test.tsx
+++ b/syntaxes/test.tsx
@@ -1,0 +1,8 @@
+const MyComponent = () => (
+  <div x-data="{ count: 0 }">
+    <button x-on:click="count++">Increment</button>
+    <span x-text="count"></span>
+  </div>
+);
+
+export default MyComponent;


### PR DESCRIPTION
The previous `injectionSelector` for TSX (`L:source.tsx`) was too generic. This change refines the selector to `L:source.tsx#meta.tag.tsx` to more accurately target TSX tags, which should improve the reliability of syntax highlighting for Alpine.js attributes within TSX files.

A test file `syntaxes/test.tsx` has been added to help verify these changes. Manual confirmation of correct highlighting in a VS Code environment is recommended.